### PR TITLE
GCI-1594: Use new schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <hamcrest-all-version>1.3</hamcrest-all-version>
         <start-class>uk.gov.companieshouse.chdorderconsumer.ChdOrderConsumerApplication</start-class>
         <structured-logging.version>1.9.0</structured-logging.version>
-        <kafka-models.version>1.0.14</kafka-models.version>
+        <kafka-models.version>1.0.16</kafka-models.version>
         <ch-kafka.version>1.4.2</ch-kafka.version>
         <spring-boot-dependencies.version>2.1.15.RELEASE</spring-boot-dependencies.version>
         <spring-boot-maven-plugin.version>2.1.15.RELEASE</spring-boot-maven-plugin.version>

--- a/src/main/java/uk/gov/companieshouse/chdorderconsumer/config/KafkaConfig.java
+++ b/src/main/java/uk/gov/companieshouse/chdorderconsumer/config/KafkaConfig.java
@@ -8,8 +8,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-import uk.gov.companieshouse.chdorderconsumer.kafka.OrderReceivedDeserializer;
-import uk.gov.companieshouse.orders.OrderReceived;
+import uk.gov.companieshouse.chdorderconsumer.kafka.ChdItemOrderedDeserializer;
+import uk.gov.companieshouse.orders.items.ChdItemOrdered;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,14 +20,14 @@ public class KafkaConfig {
     private String bootstrapServers;
 
     @Bean
-    public ConsumerFactory<String, OrderReceived> consumerFactoryMessage() {
+    public ConsumerFactory<String, ChdItemOrdered> consumerFactoryMessage() {
         return new DefaultKafkaConsumerFactory<>(consumerConfigs(), new StringDeserializer(),
-                new OrderReceivedDeserializer<>());
+                new ChdItemOrderedDeserializer<>());
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, OrderReceived> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, OrderReceived> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    public ConcurrentKafkaListenerContainerFactory<String, ChdItemOrdered> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ChdItemOrdered> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactoryMessage());
         return factory;
     }
@@ -36,7 +36,7 @@ public class KafkaConfig {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, OrderReceivedDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ChdItemOrderedDeserializer.class);
 
         return props;
     }

--- a/src/main/java/uk/gov/companieshouse/chdorderconsumer/kafka/ChdItemOrderedDeserializer.java
+++ b/src/main/java/uk/gov/companieshouse/chdorderconsumer/kafka/ChdItemOrderedDeserializer.java
@@ -8,19 +8,19 @@ import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.orders.OrderReceived;
+import uk.gov.companieshouse.orders.items.ChdItemOrdered;
 
 import java.util.Arrays;
 import java.util.Map;
 
 @Component
-public class OrderReceivedDeserializer<T extends IndexedRecord> implements Deserializer<T> {
+public class ChdItemOrderedDeserializer<T extends IndexedRecord> implements Deserializer<T> {
     @SuppressWarnings("unchecked")
     @Override
     public T deserialize(String topic, byte[] data) {
         try {
             Decoder decoder = DecoderFactory.get().binaryDecoder(data, null);
-            DatumReader<OrderReceived> reader = new ReflectDatumReader<>(OrderReceived.class);
+            DatumReader<ChdItemOrdered> reader = new ReflectDatumReader<>(ChdItemOrdered.class);
             return (T)reader.read(null, decoder);
         } catch (Exception e) {
             throw new SerializationException(

--- a/src/main/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumer.java
@@ -122,10 +122,10 @@ public class ItemOrderedKafkaConsumer implements ConsumerSeekAware {
      * @param message
      */
     protected void handleMessage(org.springframework.messaging.Message<ChdItemOrdered> message) {
-        ChdItemOrdered order = message.getPayload();
+        final ChdItemOrdered order = message.getPayload();
         final String orderReference = order.getReference();
-        MessageHeaders headers = message.getHeaders();
-        String receivedTopic = headers.get(KafkaHeaders.RECEIVED_TOPIC).toString();
+        final MessageHeaders headers = message.getHeaders();
+        final String receivedTopic = headers.get(KafkaHeaders.RECEIVED_TOPIC).toString();
         try {
             logMessageReceived(message, order);
 
@@ -135,7 +135,7 @@ public class ItemOrderedKafkaConsumer implements ConsumerSeekAware {
             }
             logMessageProcessed(message, order);
         } catch (RetryableErrorException ex) {
-            retryMessage(message, orderReference, receivedTopic, ex);
+            retryMessage(message, order, orderReference, receivedTopic, ex);
         } catch (Exception x) {
             logMessageProcessingFailureNonRecoverable(message, x);
         }
@@ -161,11 +161,13 @@ public class ItemOrderedKafkaConsumer implements ConsumerSeekAware {
      * to the next topic for failover processing, if retries match or exceed `MAX_RETRY_ATTEMPTS`.
      *
      * @param message
+     * @param order
      * @param orderReference
      * @param receivedTopic
      * @param ex
      */
     private void retryMessage(org.springframework.messaging.Message<ChdItemOrdered> message,
+                              final ChdItemOrdered order,
                               String orderReference, String receivedTopic, RetryableErrorException ex) {
         String nextTopic = (receivedTopic.equals(CHD_ITEM_ORDERED_TOPIC)
                 || receivedTopic.equals(CHD_ITEM_ORDERED_TOPIC_ERROR)) ? CHD_ITEM_ORDERED_TOPIC_RETRY

--- a/src/main/java/uk/gov/companieshouse/chdorderconsumer/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/chdorderconsumer/logging/LoggingUtils.java
@@ -19,12 +19,12 @@ public class LoggingUtils {
     public static final String OFFSET = "offset";
     public static final String KEY = "key";
     public static final String PARTITION = "partition";
-    public static final String ORDER_URI = "order_uri";
     public static final String CURRENT_TOPIC = "current_topic";
     public static final String NEXT_TOPIC = "next_topic";
     public static final String MESSAGE = "message";
     public static final String RETRY_ATTEMPT = "retry_attempt";
     public static final String CHD_ITEM_ORDERED_GROUP_ERROR = "chd_item_ordered_error";
+    public static final String ORDER_REFERENCE_NUMBER = "order_reference_number";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
 

--- a/src/main/java/uk/gov/companieshouse/chdorderconsumer/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/chdorderconsumer/logging/LoggingUtils.java
@@ -25,6 +25,9 @@ public class LoggingUtils {
     public static final String RETRY_ATTEMPT = "retry_attempt";
     public static final String CHD_ITEM_ORDERED_GROUP_ERROR = "chd_item_ordered_error";
     public static final String ORDER_REFERENCE_NUMBER = "order_reference_number";
+    public static final String ITEM_ID = "item_id";
+    public static final String PAYMENT_REFERENCE = "payment_reference";
+    public static final String COMPANY_NUMBER = "company_number";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
 

--- a/src/main/java/uk/gov/companieshouse/chdorderconsumer/logging/LoggingUtils.java
+++ b/src/main/java/uk/gov/companieshouse/chdorderconsumer/logging/LoggingUtils.java
@@ -5,7 +5,7 @@ import org.springframework.messaging.MessageHeaders;
 import uk.gov.companieshouse.kafka.message.Message;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
-import uk.gov.companieshouse.orders.OrderReceived;
+import uk.gov.companieshouse.orders.items.ChdItemOrdered;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +37,7 @@ public class LoggingUtils {
     }
 
     public static Map<String, Object> getMessageHeadersAsMap(
-            org.springframework.messaging.Message<OrderReceived> message) {
+            org.springframework.messaging.Message<ChdItemOrdered> message) {
         Map<String, Object> logMap = LoggingUtils.createLogMap();
         MessageHeaders messageHeaders = message.getHeaders();
 

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ChdItemOrderedDeserializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ChdItemOrderedDeserializerTest.java
@@ -9,18 +9,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.orders.OrderReceived;
+import uk.gov.companieshouse.orders.items.ChdItemOrdered;
 
 import java.io.IOException;
 
 @ExtendWith(MockitoExtension.class)
-public class OrderReceivedDeserializerTest {
+public class ChdItemOrderedDeserializerTest {
     @InjectMocks
-    private OrderReceivedDeserializer deserializer;
+    private ChdItemOrderedDeserializer deserializer;
     @Mock
     private BinaryDecoder binaryDecoder;
     @Mock
-    private DatumReader<OrderReceived> datumReader;
+    private DatumReader<ChdItemOrdered> datumReader;
 
     @Test
     public void deserializeThrowsSerializationException() throws IOException {

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ChdItemOrderedDeserializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ChdItemOrderedDeserializerTest.java
@@ -14,7 +14,7 @@ import uk.gov.companieshouse.orders.items.ChdItemOrdered;
 import java.io.IOException;
 
 @ExtendWith(MockitoExtension.class)
-public class ChdItemOrderedDeserializerTest {
+class ChdItemOrderedDeserializerTest {
     @InjectMocks
     private ChdItemOrderedDeserializer deserializer;
     @Mock
@@ -23,7 +23,7 @@ public class ChdItemOrderedDeserializerTest {
     private DatumReader<ChdItemOrdered> datumReader;
 
     @Test
-    public void deserializeThrowsSerializationException() throws IOException {
+    void deserializeThrowsSerializationException() throws IOException {
         byte[] testData = new String("Test data").getBytes();
 
         Assertions.assertThrows(SerializationException.class, () -> deserializer.deserialize("chd-item-ordered", testData));

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationDefaultModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationDefaultModeTest.java
@@ -103,8 +103,7 @@ class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
     @DisplayName("chd-item-ordered-error topic consumer does not receive message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER) is false")
     void testItemOrderedConsumerReceivesChdItemOrderedMessage1Error() throws Exception {
         // When
-        kafkaProducer.sendMessage(consumerWrapper.createMessage(
-                createOrder(), ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC_ERROR));
+        kafkaProducer.sendMessage(consumerWrapper.createMessage(createOrder(), CHD_ITEM_ORDERED_TOPIC_ERROR));
 
         // Then
         verifyProcessChdItemOrderedNotInvoked(CHConsumerType.ERROR_CONSUMER);
@@ -127,7 +126,7 @@ class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
         final ChdItemOrdered order = createOrder();
 
         // When
-        kafkaProducer.sendMessage(consumerWrapper.createMessage(order, ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC));
+        kafkaProducer.sendMessage(consumerWrapper.createMessage(order, CHD_ITEM_ORDERED_TOPIC));
 
         // Then
         verifyProcessChdItemOrderedInvoked(order, CHConsumerType.MAIN_CONSUMER);
@@ -142,7 +141,7 @@ class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
         final ChdItemOrdered order = createOrder();
 
         // When
-        kafkaProducer.sendMessage(consumerWrapper.createMessage(order, ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC_RETRY));
+        kafkaProducer.sendMessage(consumerWrapper.createMessage(order, CHD_ITEM_ORDERED_TOPIC_RETRY));
 
         // Then
         verifyProcessChdItemOrderedInvoked(order, CHConsumerType.RETRY_CONSUMER);

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationDefaultModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationDefaultModeTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static uk.gov.companieshouse.chdorderconsumer.util.TestUtils.assertJsonsEqualIgnoringFieldOrdering;
 import static uk.gov.companieshouse.chdorderconsumer.util.TestUtils.createOrder;
 
 @SpringBootTest
@@ -46,7 +47,6 @@ class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
     private static final String CHD_ITEM_ORDERED_TOPIC_RETRY = "chd-item-ordered-retry";
     private static final String CHD_ITEM_ORDERED_TOPIC_ERROR = "chd-item-ordered-error";
     private static final String GROUP_NAME = "chd-item-ordered-consumers";
-    private static final String ORDER_REFERENCE = "ORD-123456-123456";
 
     @Value("${spring.kafka.bootstrap-servers}")
     private String brokerAddresses;
@@ -153,6 +153,7 @@ class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
         consumerWrapper.getLatch().await(3000, TimeUnit.MILLISECONDS);
         assertThat(consumerWrapper.getLatch().getCount(), is(equalTo(0L)));
         final String messagePayload = consumerWrapper.getMessagePayload();
-        assertThat(messagePayload, is(equalTo(order.toString())));
+        assertJsonsEqualIgnoringFieldOrdering(messagePayload, order.toString());
     }
+
 }

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationDefaultModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationDefaultModeTest.java
@@ -41,13 +41,14 @@ import static org.hamcrest.Matchers.isEmptyOrNullString;
 @EmbeddedKafka
 @TestPropertySource(properties={"uk.gov.companieshouse.chdorderconsumer.error-consumer=false"})
 @TestMethodOrder(MethodOrderer.Alphanumeric.class)
-public class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
+class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
 
     private static final String CHD_ITEM_ORDERED_TOPIC = "chd-item-ordered";
     private static final String CHD_ITEM_ORDERED_TOPIC_RETRY = "chd-item-ordered-retry";
     private static final String CHD_ITEM_ORDERED_TOPIC_ERROR = "chd-item-ordered-error";
     private static final String GROUP_NAME = "chd-item-ordered-consumers";
-    private static final String ORDER_RECEIVED_URI = "/orders/ORD-123456-123456";
+    private static final String ORDER_REFERENCE = "ORD-123456-123456";
+    // TODO GCI-1594 correct expected content and constant name
     private static final String ORDER_RECEIVED_MESSAGE_JSON = "{\"order_uri\": \"/orders/ORD-123456-123456\"}";
 
     @Value("${spring.kafka.bootstrap-servers}")
@@ -105,7 +106,7 @@ public class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
     @DisplayName("chd-item-ordered-error topic consumer does not receive message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER) is false")
     void testItemOrderedConsumerReceivesChdItemOrderedMessage1Error() throws InterruptedException, ExecutionException, SerializationException {
         // When
-        kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_RECEIVED_URI, CHD_ITEM_ORDERED_TOPIC_ERROR));
+        kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC_ERROR));
 
         // Then
         verifyProcessChdItemOrderedNotInvoked(CHConsumerType.ERROR_CONSUMER);
@@ -115,8 +116,8 @@ public class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
         consumerWrapper.setTestType(type);
         consumerWrapper.getLatch().await(3000, TimeUnit.MILLISECONDS);
         assertThat(consumerWrapper.getLatch().getCount(), is(equalTo(1L)));
-        String processedOrderUri = consumerWrapper.getOrderUri();
-        assertThat(processedOrderUri, isEmptyOrNullString());
+        String processedOrderReference = consumerWrapper.getOrderReference();
+        assertThat(processedOrderReference, isEmptyOrNullString());
     }
 
     @Test
@@ -124,7 +125,7 @@ public class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
     @DisplayName("chd-item-ordered topic consumer receives message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER) is false")
     void testItemOrderedConsumerReceivesChdItemOrderedMessage2() throws InterruptedException, ExecutionException, SerializationException {
         // When
-        kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_RECEIVED_URI, CHD_ITEM_ORDERED_TOPIC));
+        kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC));
 
         // Then
         verifyProcessChdItemOrderedInvoked(CHConsumerType.MAIN_CONSUMER);
@@ -135,7 +136,7 @@ public class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
     @DisplayName("chd-item-ordered topic consumer receives message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER) is false")
     void testItemOrderedConsumerReceivesChdItemOrderedMessage3Retry() throws InterruptedException, ExecutionException, SerializationException {
         // When
-        kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_RECEIVED_URI, CHD_ITEM_ORDERED_TOPIC_RETRY));
+        kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC_RETRY));
 
         // Then
         verifyProcessChdItemOrderedInvoked(CHConsumerType.RETRY_CONSUMER);
@@ -145,7 +146,7 @@ public class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
         consumerWrapper.setTestType(type);
         consumerWrapper.getLatch().await(3000, TimeUnit.MILLISECONDS);
         assertThat(consumerWrapper.getLatch().getCount(), is(equalTo(0L)));
-        String processedOrderUri = consumerWrapper.getOrderUri();
-        assertThat(processedOrderUri, is(equalTo(ORDER_RECEIVED_MESSAGE_JSON)));
+        String processedOrderReference = consumerWrapper.getOrderReference();
+        assertThat(processedOrderReference, is(equalTo(ORDER_RECEIVED_MESSAGE_JSON)));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationDefaultModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationDefaultModeTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.context.TestPropertySource;
 import uk.gov.companieshouse.kafka.consumer.resilience.CHConsumerType;
 import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
-import uk.gov.companieshouse.orders.OrderReceived;
+import uk.gov.companieshouse.orders.items.ChdItemOrdered;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -57,7 +57,7 @@ public class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
     @Autowired
     private ItemOrderedKafkaProducer kafkaProducer;
 
-    private KafkaMessageListenerContainer<String, OrderReceived> container;
+    private KafkaMessageListenerContainer<String, ChdItemOrdered> container;
 
     private BlockingQueue<ConsumerRecord<String, String>> records;
 
@@ -77,11 +77,11 @@ public class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
     private void setUpTestKafkaItemOrderedConsumer() {
         final Map<String, Object> consumerProperties = new HashMap<>();
         consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, OrderReceivedDeserializer.class);
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ChdItemOrderedDeserializer.class);
         consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_NAME);
         consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerAddresses);
 
-        final DefaultKafkaConsumerFactory<String, OrderReceived> consumerFactory =
+        final DefaultKafkaConsumerFactory<String, ChdItemOrdered> consumerFactory =
                 new DefaultKafkaConsumerFactory<>(consumerProperties);
 
         final ContainerProperties containerProperties = new ContainerProperties(
@@ -103,15 +103,15 @@ public class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
     @Test
     @DirtiesContext
     @DisplayName("chd-item-ordered-error topic consumer does not receive message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER) is false")
-    void testItemOrderedConsumerReceivesOrderReceivedMessage1Error() throws InterruptedException, ExecutionException, SerializationException {
+    void testItemOrderedConsumerReceivesChdItemOrderedMessage1Error() throws InterruptedException, ExecutionException, SerializationException {
         // When
         kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_RECEIVED_URI, CHD_ITEM_ORDERED_TOPIC_ERROR));
 
         // Then
-        verifyProcessOrderReceivedNotInvoked(CHConsumerType.ERROR_CONSUMER);
+        verifyProcessChdItemOrderedNotInvoked(CHConsumerType.ERROR_CONSUMER);
     }
 
-    private void verifyProcessOrderReceivedNotInvoked(CHConsumerType type) throws InterruptedException {
+    private void verifyProcessChdItemOrderedNotInvoked(CHConsumerType type) throws InterruptedException {
         consumerWrapper.setTestType(type);
         consumerWrapper.getLatch().await(3000, TimeUnit.MILLISECONDS);
         assertThat(consumerWrapper.getLatch().getCount(), is(equalTo(1L)));
@@ -122,26 +122,26 @@ public class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
     @Test
     @DirtiesContext
     @DisplayName("chd-item-ordered topic consumer receives message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER) is false")
-    void testItemOrderedConsumerReceivesOrderReceivedMessage2() throws InterruptedException, ExecutionException, SerializationException {
+    void testItemOrderedConsumerReceivesChdItemOrderedMessage2() throws InterruptedException, ExecutionException, SerializationException {
         // When
         kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_RECEIVED_URI, CHD_ITEM_ORDERED_TOPIC));
 
         // Then
-        verifyProcessOrderReceivedInvoked(CHConsumerType.MAIN_CONSUMER);
+        verifyProcessChdItemOrderedInvoked(CHConsumerType.MAIN_CONSUMER);
     }
 
     @Test
     @DirtiesContext
     @DisplayName("chd-item-ordered topic consumer receives message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER) is false")
-    void testItemOrderedConsumerReceivesOrderReceivedMessage3Retry() throws InterruptedException, ExecutionException, SerializationException {
+    void testItemOrderedConsumerReceivesChdItemOrderedMessage3Retry() throws InterruptedException, ExecutionException, SerializationException {
         // When
         kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_RECEIVED_URI, CHD_ITEM_ORDERED_TOPIC_RETRY));
 
         // Then
-        verifyProcessOrderReceivedInvoked(CHConsumerType.RETRY_CONSUMER);
+        verifyProcessChdItemOrderedInvoked(CHConsumerType.RETRY_CONSUMER);
     }
 
-    private void verifyProcessOrderReceivedInvoked(CHConsumerType type) throws InterruptedException {
+    private void verifyProcessChdItemOrderedInvoked(CHConsumerType type) throws InterruptedException {
         consumerWrapper.setTestType(type);
         consumerWrapper.getLatch().await(3000, TimeUnit.MILLISECONDS);
         assertThat(consumerWrapper.getLatch().getCount(), is(equalTo(0L)));

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationDefaultModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationDefaultModeTest.java
@@ -21,14 +21,12 @@ import org.springframework.kafka.test.utils.ContainerTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import uk.gov.companieshouse.kafka.consumer.resilience.CHConsumerType;
-import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
 import uk.gov.companieshouse.orders.items.ChdItemOrdered;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -36,6 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static uk.gov.companieshouse.chdorderconsumer.util.TestUtils.createOrder;
 
 @SpringBootTest
 @EmbeddedKafka
@@ -48,8 +47,6 @@ class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
     private static final String CHD_ITEM_ORDERED_TOPIC_ERROR = "chd-item-ordered-error";
     private static final String GROUP_NAME = "chd-item-ordered-consumers";
     private static final String ORDER_REFERENCE = "ORD-123456-123456";
-    // TODO GCI-1594 correct expected content and constant name
-    private static final String ORDER_RECEIVED_MESSAGE_JSON = "{\"order_uri\": \"/orders/ORD-123456-123456\"}";
 
     @Value("${spring.kafka.bootstrap-servers}")
     private String brokerAddresses;
@@ -104,9 +101,10 @@ class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
     @Test
     @DirtiesContext
     @DisplayName("chd-item-ordered-error topic consumer does not receive message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER) is false")
-    void testItemOrderedConsumerReceivesChdItemOrderedMessage1Error() throws InterruptedException, ExecutionException, SerializationException {
+    void testItemOrderedConsumerReceivesChdItemOrderedMessage1Error() throws Exception {
         // When
-        kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC_ERROR));
+        kafkaProducer.sendMessage(consumerWrapper.createMessage(
+                createOrder(), ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC_ERROR));
 
         // Then
         verifyProcessChdItemOrderedNotInvoked(CHConsumerType.ERROR_CONSUMER);
@@ -116,37 +114,46 @@ class ItemOrderedKafkaConsumerIntegrationDefaultModeTest {
         consumerWrapper.setTestType(type);
         consumerWrapper.getLatch().await(3000, TimeUnit.MILLISECONDS);
         assertThat(consumerWrapper.getLatch().getCount(), is(equalTo(1L)));
-        String processedOrderReference = consumerWrapper.getOrderReference();
+        String processedOrderReference = consumerWrapper.getMessagePayload();
         assertThat(processedOrderReference, isEmptyOrNullString());
     }
 
     @Test
     @DirtiesContext
     @DisplayName("chd-item-ordered topic consumer receives message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER) is false")
-    void testItemOrderedConsumerReceivesChdItemOrderedMessage2() throws InterruptedException, ExecutionException, SerializationException {
+    void testItemOrderedConsumerReceivesChdItemOrderedMessage2() throws Exception {
+
+        // Given
+        final ChdItemOrdered order = createOrder();
+
         // When
-        kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC));
+        kafkaProducer.sendMessage(consumerWrapper.createMessage(order, ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC));
 
         // Then
-        verifyProcessChdItemOrderedInvoked(CHConsumerType.MAIN_CONSUMER);
+        verifyProcessChdItemOrderedInvoked(order, CHConsumerType.MAIN_CONSUMER);
     }
 
     @Test
     @DirtiesContext
     @DisplayName("chd-item-ordered topic consumer receives message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER) is false")
-    void testItemOrderedConsumerReceivesChdItemOrderedMessage3Retry() throws InterruptedException, ExecutionException, SerializationException {
+    void testItemOrderedConsumerReceivesChdItemOrderedMessage3Retry() throws Exception {
+
+        // Given
+        final ChdItemOrdered order = createOrder();
+
         // When
-        kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC_RETRY));
+        kafkaProducer.sendMessage(consumerWrapper.createMessage(order, ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC_RETRY));
 
         // Then
-        verifyProcessChdItemOrderedInvoked(CHConsumerType.RETRY_CONSUMER);
+        verifyProcessChdItemOrderedInvoked(order, CHConsumerType.RETRY_CONSUMER);
     }
 
-    private void verifyProcessChdItemOrderedInvoked(CHConsumerType type) throws InterruptedException {
+    private void verifyProcessChdItemOrderedInvoked(final ChdItemOrdered order,
+                                                    final CHConsumerType type) throws Exception {
         consumerWrapper.setTestType(type);
         consumerWrapper.getLatch().await(3000, TimeUnit.MILLISECONDS);
         assertThat(consumerWrapper.getLatch().getCount(), is(equalTo(0L)));
-        String processedOrderReference = consumerWrapper.getOrderReference();
-        assertThat(processedOrderReference, is(equalTo(ORDER_RECEIVED_MESSAGE_JSON)));
+        final String messagePayload = consumerWrapper.getMessagePayload();
+        assertThat(messagePayload, is(equalTo(order.toString())));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationErrorModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationErrorModeTest.java
@@ -103,7 +103,7 @@ class ItemOrderedKafkaConsumerIntegrationErrorModeTest {
     @DisplayName("chd-item-ordered topic consumer does not receive message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER)is true")
     void testItemOrderedConsumerReceivesChdItemOrderedMessage1() throws Exception {
         // When
-        kafkaProducer.sendMessage(consumerWrapper.createMessage(createOrder(), ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC));
+        kafkaProducer.sendMessage(consumerWrapper.createMessage(createOrder(), CHD_ITEM_ORDERED_TOPIC));
 
         // Then
         verifyProcessChdItemOrderedNotInvoked(CHConsumerType.MAIN_CONSUMER);
@@ -113,8 +113,7 @@ class ItemOrderedKafkaConsumerIntegrationErrorModeTest {
     @DisplayName("chd-item-ordered-retry topic consumer does not receive message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER)is true")
     void testItemOrderedConsumerReceivesChdItemOrderedMessage2Retry() throws Exception {
         // When
-        kafkaProducer.sendMessage(consumerWrapper.createMessage(
-                createOrder(), ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC_RETRY));
+        kafkaProducer.sendMessage(consumerWrapper.createMessage(createOrder(), CHD_ITEM_ORDERED_TOPIC_RETRY));
 
         // Then
         verifyProcessChdItemOrderedNotInvoked(CHConsumerType.RETRY_CONSUMER);
@@ -135,7 +134,7 @@ class ItemOrderedKafkaConsumerIntegrationErrorModeTest {
         final ChdItemOrdered order = createOrder();
 
         // When
-        kafkaProducer.sendMessage(consumerWrapper.createMessage(order, ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC_ERROR));
+        kafkaProducer.sendMessage(consumerWrapper.createMessage(order, CHD_ITEM_ORDERED_TOPIC_ERROR));
 
         // Then
         verifyProcessChdItemOrderedInvoked(order, CHConsumerType.ERROR_CONSUMER);

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationErrorModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationErrorModeTest.java
@@ -31,9 +31,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static uk.gov.companieshouse.chdorderconsumer.util.TestUtils.assertJsonsEqualIgnoringFieldOrdering;
 import static uk.gov.companieshouse.chdorderconsumer.util.TestUtils.createOrder;
 
 @SpringBootTest
@@ -141,10 +140,10 @@ class ItemOrderedKafkaConsumerIntegrationErrorModeTest {
     }
 
     private void verifyProcessChdItemOrderedInvoked(final ChdItemOrdered order,
-                                                    final CHConsumerType type) throws InterruptedException {
+                                                    final CHConsumerType type) throws Exception {
         consumerWrapper.setTestType(type);
         consumerWrapper.getLatch().await(6000, TimeUnit.MILLISECONDS);
         final String messagePayload = consumerWrapper.getMessagePayload();
-        assertThat(messagePayload, is(equalTo(order.toString())));
+        assertJsonsEqualIgnoringFieldOrdering(messagePayload, order.toString());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationErrorModeTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerIntegrationErrorModeTest.java
@@ -102,25 +102,25 @@ public class ItemOrderedKafkaConsumerIntegrationErrorModeTest {
 
     @Test
     @DisplayName("chd-item-ordered topic consumer does not receive message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER)is true")
-    void testItemOrderedConsumerReceivesOrderReceivedMessage1() throws InterruptedException, ExecutionException, SerializationException {
+    void testItemOrderedConsumerReceivesChdItemOrderedMessage1() throws InterruptedException, ExecutionException, SerializationException {
         // When
         kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_RECEIVED_URI, CHD_ITEM_ORDERED_TOPIC));
 
         // Then
-        verifyProcessOrderReceivedNotInvoked(CHConsumerType.MAIN_CONSUMER);
+        verifyProcessChdItemOrderedNotInvoked(CHConsumerType.MAIN_CONSUMER);
     }
 
     @Test
     @DisplayName("chd-item-ordered-retry topic consumer does not receive message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER)is true")
-    void testItemOrderedConsumerReceivesOrderReceivedMessage2Retry() throws InterruptedException, SerializationException, ExecutionException {
+    void testItemOrderedConsumerReceivesChdItemOrderedMessage2Retry() throws InterruptedException, SerializationException, ExecutionException {
         // When
         kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_RECEIVED_URI, CHD_ITEM_ORDERED_TOPIC_RETRY));
 
         // Then
-        verifyProcessOrderReceivedNotInvoked(CHConsumerType.RETRY_CONSUMER);
+        verifyProcessChdItemOrderedNotInvoked(CHConsumerType.RETRY_CONSUMER);
     }
 
-    private void verifyProcessOrderReceivedNotInvoked(CHConsumerType type) throws InterruptedException {
+    private void verifyProcessChdItemOrderedNotInvoked(CHConsumerType type) throws InterruptedException {
         consumerWrapper.setTestType(type);
         consumerWrapper.getLatch().await(3000, TimeUnit.MILLISECONDS);
         final String processedOrderUri = consumerWrapper.getOrderUri();
@@ -129,15 +129,15 @@ public class ItemOrderedKafkaConsumerIntegrationErrorModeTest {
 
     @Test
     @DisplayName("chd-item-ordered-error topic consumer receives message when 'error-consumer' (env var IS_ERROR_QUEUE_CONSUMER) is true")
-    void testItemOrderedConsumerReceivesOrderReceivedMessage3Error() throws InterruptedException, ExecutionException, SerializationException {
+    void testItemOrderedConsumerReceivesChdItemOrderedMessage3Error() throws InterruptedException, ExecutionException, SerializationException {
         // When
         kafkaProducer.sendMessage(consumerWrapper.createMessage(ORDER_RECEIVED_URI, CHD_ITEM_ORDERED_TOPIC_ERROR));
 
         // Then
-        verifyProcessOrderReceivedInvoked(CHConsumerType.ERROR_CONSUMER);
+        verifyProcessChdItemOrderedInvoked(CHConsumerType.ERROR_CONSUMER);
     }
 
-    private void verifyProcessOrderReceivedInvoked(CHConsumerType type) throws InterruptedException {
+    private void verifyProcessChdItemOrderedInvoked(CHConsumerType type) throws InterruptedException {
         consumerWrapper.setTestType(type);
         consumerWrapper.getLatch().await(6000, TimeUnit.MILLISECONDS);
         final String processedOrderUri = consumerWrapper.getOrderUri();

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerTest.java
@@ -51,6 +51,8 @@ class ItemOrderedKafkaConsumerTest {
     private SerializerFactory serializerFactory;
     @Mock
     private AvroSerializer serializer;
+    @Mock
+    private org.springframework.messaging.Message<ChdItemOrdered> message;
     @Captor
     ArgumentCaptor<String> orderReferenceArgument;
     @Captor
@@ -160,7 +162,7 @@ class ItemOrderedKafkaConsumerTest {
         // Given & When
         doThrow(new RetryableErrorException(PROCESSING_ERROR_MESSAGE)).when(kafkaConsumer).processChdItemOrdered(any());
         RetryableErrorException exception = Assertions.assertThrows(RetryableErrorException.class, () -> {
-            kafkaConsumer.processChdItemOrdered(any());
+            kafkaConsumer.processChdItemOrdered(message);
         });
         // Then
         String actualMessage = exception.getMessage();
@@ -173,7 +175,7 @@ class ItemOrderedKafkaConsumerTest {
         // Given & When
         doThrow(new RetryableErrorException(PROCESSING_ERROR_MESSAGE)).when(kafkaConsumer).processChdItemOrderedRetry(any());
         RetryableErrorException exception = Assertions.assertThrows(RetryableErrorException.class, () -> {
-            kafkaConsumer.processChdItemOrderedRetry(any());
+            kafkaConsumer.processChdItemOrderedRetry(message);
         });
         // Then
         String actualMessage = exception.getMessage();
@@ -186,7 +188,7 @@ class ItemOrderedKafkaConsumerTest {
         // Given & When
         doThrow(new RetryableErrorException(PROCESSING_ERROR_MESSAGE)).when(kafkaConsumer).processChdItemOrderedError(any());
         RetryableErrorException exception = Assertions.assertThrows(RetryableErrorException.class, () -> {
-            kafkaConsumer.processChdItemOrderedError(any());
+            kafkaConsumer.processChdItemOrderedError(message);
         });
         // Then
         String actualMessage = exception.getMessage();

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerTest.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.chdorderconsumer.kafka;
 
-import org.apache.avro.generic.IndexedRecord;
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,11 +31,11 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.chdorderconsumer.util.TestConstants.ORDER_REFERENCE;
 import static uk.gov.companieshouse.chdorderconsumer.util.TestUtils.createOrder;
 
 @ExtendWith(MockitoExtension.class)
 class ItemOrderedKafkaConsumerTest {
-    private static final String ORDER_REFERENCE = "ORD-123456-123456";
     private static final String CHD_ITEM_ORDERED_TOPIC = "chd-item-ordered";
     private static final String CHD_ITEM_ORDERED_KEY = "chd-item-ordered";
     private static final String CHD_ITEM_ORDERED_TOPIC_RETRY = "chd-item-ordered-retry";
@@ -200,13 +198,7 @@ class ItemOrderedKafkaConsumerTest {
         return new org.springframework.messaging.Message<ChdItemOrdered>() {
             @Override
             public ChdItemOrdered getPayload() {
-                ChdItemOrdered chdItemOrdered = new ChdItemOrdered();
-
-                // TODO GCI-1594 deal with ChdItemOrdered attributes.
-                //chdItemOrdered.setOrderUri(ORDER_RECEIVED_URI);
-                chdItemOrdered.setReference(ORDER_REFERENCE);
-
-                return chdItemOrdered;
+                return createOrder();
             }
 
             @Override

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerWrapper.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/kafka/ItemOrderedKafkaConsumerWrapper.java
@@ -94,25 +94,19 @@ public class ItemOrderedKafkaConsumerWrapper {
 
         final ChdItemOrdered order = createOrder();
         if (this.testType == CHConsumerType.MAIN_CONSUMER) {
-            kafkaProducer.sendMessage(createMessage(order, ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC));
+            kafkaProducer.sendMessage(createMessage(order, CHD_ITEM_ORDERED_TOPIC));
         } else if (this.testType == CHConsumerType.RETRY_CONSUMER) {
-            kafkaProducer.sendMessage(createMessage(order, ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC_RETRY));
+            kafkaProducer.sendMessage(createMessage(order, CHD_ITEM_ORDERED_TOPIC_RETRY));
         } else if (this.testType == CHConsumerType.ERROR_CONSUMER) {
-            kafkaProducer.sendMessage(createMessage(order, ORDER_REFERENCE, CHD_ITEM_ORDERED_TOPIC_ERROR));
+            kafkaProducer.sendMessage(createMessage(order, CHD_ITEM_ORDERED_TOPIC_ERROR));
         }
     }
 
     public uk.gov.companieshouse.kafka.message.Message createMessage(final ChdItemOrdered order,
-                                                                     final String orderReference,
                                                                      final String topic) throws SerializationException {
         final uk.gov.companieshouse.kafka.message.Message message = new uk.gov.companieshouse.kafka.message.Message();
         final AvroSerializer<ChdItemOrdered> serializer =
                 serializerFactory.getGenericRecordSerializer(ChdItemOrdered.class);
-
-        // TODO GCI-1594 deal with ChdItemOrdered attributes.
-        //chdItemOrdered.setOrderUri(orderUri.trim());
-        order.setReference(orderReference.trim());
-
         message.setKey(CHD_ITEM_ORDERED_KEY_RETRY);
         message.setValue(serializer.toBinary(order));
         message.setTopic(topic);

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/util/TestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/util/TestUtils.java
@@ -1,0 +1,63 @@
+package uk.gov.companieshouse.chdorderconsumer.util;
+
+import uk.gov.companieshouse.orders.items.ChdItemOrdered;
+import uk.gov.companieshouse.orders.items.Item;
+import uk.gov.companieshouse.orders.items.ItemCosts;
+import uk.gov.companieshouse.orders.items.Links;
+import uk.gov.companieshouse.orders.items.OrderedBy;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static uk.gov.companieshouse.chdorderconsumer.util.TestConstants.MISSING_IMAGE_DELIVERY_ITEM_ID;
+import static uk.gov.companieshouse.chdorderconsumer.util.TestConstants.ORDER_REFERENCE;
+
+public class TestUtils {
+
+    /**
+     * Creates a valid single MID item order with all the required fields populated.
+     * @return a fully populated {@link ChdItemOrdered} object
+     */
+    public static ChdItemOrdered createOrder() {
+        final ChdItemOrdered order = new ChdItemOrdered();
+        final Item item = new Item();
+        item.setId(MISSING_IMAGE_DELIVERY_ITEM_ID);
+        order.setItem(item);
+        order.setOrderedAt(LocalDateTime.now().toString());
+        final OrderedBy orderedBy = new OrderedBy();
+        orderedBy.setEmail("demo@ch.gov.uk");
+        orderedBy.setId("4Y2VkZWVlMzhlZWFjY2M4MzQ3M1234");
+        order.setOrderedBy(orderedBy);
+// TODO GCI-1594 Check product type is conveyed correctly to this consumer
+        final ItemCosts costs = new ItemCosts("0", "3", "3", "missing-image-delivery-accounts");
+        item.setItemCosts(singletonList(costs));
+// TODO GCI-1594 Options
+//        final MissingImageDeliveryItemOptions options = new MissingImageDeliveryItemOptions();
+//        item.setItemOptions(options);
+        item.setItemOptions(new HashMap<>());
+        final Links links = new Links();
+        links.setSelf("/orderable/missing-image-deliveries/MID-535516-028321");
+        item.setLinks(links);
+        item.setQuantity(1);
+        item.setCompanyName("THE GIRLS' DAY SCHOOL TRUST");
+        item.setCompanyNumber("00006400");
+        item.setCustomerReference("MID ordered by VJ GCI-1301");
+        item.setDescription("missing image delivery for company 00006400");
+        item.setDescriptionIdentifier("missing-image-delivery");
+        final Map<String, String> descriptionValues = new HashMap<>();
+        descriptionValues.put("company_number", "00006400");
+        descriptionValues.put("missing-image-delivery", "missing image delivery for company 00006400");
+        item.setDescriptionValues(descriptionValues);
+        item.setItemUri("/orderable/missing-image-deliveries/MID-535516-028321");
+        item.setKind("item#missing-image-delivery");
+        item.setTotalItemCost("3");
+        item.setPostageCost("0");
+        order.setPaymentReference("1234");
+        order.setReference(ORDER_REFERENCE);
+        order.setTotalOrderCost("3");
+        return order;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/util/TestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/util/TestUtils.java
@@ -1,20 +1,27 @@
 package uk.gov.companieshouse.chdorderconsumer.util;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.orders.items.ChdItemOrdered;
 import uk.gov.companieshouse.orders.items.Item;
 import uk.gov.companieshouse.orders.items.ItemCosts;
 import uk.gov.companieshouse.orders.items.Links;
 import uk.gov.companieshouse.orders.items.OrderedBy;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static uk.gov.companieshouse.chdorderconsumer.util.TestConstants.MISSING_IMAGE_DELIVERY_ITEM_ID;
 import static uk.gov.companieshouse.chdorderconsumer.util.TestConstants.ORDER_REFERENCE;
 
 public class TestUtils {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
      * Creates a valid single MID item order with all the required fields populated.
@@ -33,10 +40,15 @@ public class TestUtils {
 // TODO GCI-1594 Check product type is conveyed correctly to this consumer
         final ItemCosts costs = new ItemCosts("0", "3", "3", "missing-image-delivery-accounts");
         item.setItemCosts(singletonList(costs));
-// TODO GCI-1594 Options
-//        final MissingImageDeliveryItemOptions options = new MissingImageDeliveryItemOptions();
-//        item.setItemOptions(options);
-        item.setItemOptions(new HashMap<>());
+        final Map<String, String> options = new HashMap<>();
+        options.put("filingHistoryDescriptionValues",
+                "{\"change_date\":\"2010-02-12\",\"officer_name\":\"Thomas David Wheare\"}");
+        options.put("filingHistoryCategory", "officers");
+        options.put("filingHistoryDate", "2010-02-12");
+        options.put("filingHistoryDescription", "change-person-director-company-with-change-date");
+        options.put("filingHistoryId", "MzAwOTM2MDg5OWFkaXF6a2N4");
+        options.put("filingHistoryType", "CH01");
+        item.setItemOptions(options);
         final Links links = new Links();
         links.setSelf("/orderable/missing-image-deliveries/MID-535516-028321");
         item.setLinks(links);
@@ -58,6 +70,18 @@ public class TestUtils {
         order.setReference(ORDER_REFERENCE);
         order.setTotalOrderCost("3");
         return order;
+    }
+
+    /**
+     * Asserts that two JSON strings are equal, ignoring any differences in the ordering of fields.
+     * @param json1 the first JSON string
+     * @param json2 the second JSON string
+     * @throws IOException should something unexpected happen.
+     */
+    public static void assertJsonsEqualIgnoringFieldOrdering(final String json1, final String json2) throws IOException  {
+        final JsonNode payloadJsonNode = MAPPER.readTree(json1);
+        final JsonNode orderJsonNode = MAPPER.readTree(json2);
+        assertThat(payloadJsonNode.equals(orderJsonNode), is(true));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/util/TestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/util/TestUtils.java
@@ -37,7 +37,6 @@ public class TestUtils {
         orderedBy.setEmail("demo@ch.gov.uk");
         orderedBy.setId("4Y2VkZWVlMzhlZWFjY2M4MzQ3M1234");
         order.setOrderedBy(orderedBy);
-// TODO GCI-1594 Check product type is conveyed correctly to this consumer
         final ItemCosts costs = new ItemCosts("0", "3", "3", "missing-image-delivery-accounts");
         item.setItemCosts(singletonList(costs));
         final Map<String, String> options = new HashMap<>();


### PR DESCRIPTION
* Change the `chd-order-consumer` from temporarily consuming messages of the `OrderReceived` type to consuming messages of the `ChdItemOrdered` type, as appropriate for the `chd-item-ordered` topic.