### PR TITLE
Gci 1672 log 409 status code for duplicate submissions

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chdorderconsumer/exception/DuplicateErrorException.java
+++ b/src/main/java/uk/gov/companieshouse/chdorderconsumer/exception/DuplicateErrorException.java
@@ -1,0 +1,9 @@
+package uk.gov.companieshouse.chdorderconsumer.exception;
+
+public class DuplicateErrorException extends RuntimeException {
+
+    public DuplicateErrorException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
Handle 409 (Conflict) status code which indicates that the request could not be completed due to a conflict with the current state of the target resource, and stop the retrying.