### PR TITLE
GCI-1678 - Add call to mongo to get barcode 

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chdorderconsumer/service/ItemOrderedProcessorService.java
+++ b/src/main/java/uk/gov/companieshouse/chdorderconsumer/service/ItemOrderedProcessorService.java
@@ -51,8 +51,15 @@ public class ItemOrderedProcessorService {
         missingImageDeliveryRequestApi.setFilingHistoryBarcode(itemOptions.get("filingHistoryBarcode"));
         missingImageDeliveryRequestApi.setItemCost(item.getTotalItemCost());
 
-        String entityID = mongoService.getEntityId(itemOptions.get("filingHistoryId"));
-        missingImageDeliveryRequestApi.setEntityId(entityID);
+        String filingHistoryId = itemOptions.get("filingHistoryId");
+
+        missingImageDeliveryRequestApi.setEntityId(mongoService.getEntityId(filingHistoryId));
+
+        if (missingImageDeliveryRequestApi.getEntityId() == null &&
+            missingImageDeliveryRequestApi.getFilingHistoryBarcode() == null) {
+
+            missingImageDeliveryRequestApi.setFilingHistoryBarcode(mongoService.getBarcode(filingHistoryId));
+        }
 
         return missingImageDeliveryRequestApi;
     }

--- a/src/main/java/uk/gov/companieshouse/chdorderconsumer/service/MongoService.java
+++ b/src/main/java/uk/gov/companieshouse/chdorderconsumer/service/MongoService.java
@@ -16,6 +16,7 @@ public class MongoService {
     private static final String MONGO_DATABASE_NAME = "MONGO_DATABASE_NAME";
     private static final String MONGO_COLLECTION = "MONGO_COLLECTION";
     private static final String ENTITY_ID_FIELD = "ENTITY_ID_FIELD";
+    private static final String BARCODE_FIELD = "barcode";
 
     @Autowired
     private MongoClient mongoClient;
@@ -24,14 +25,13 @@ public class MongoService {
     private EnvironmentReader environmentReader;
 
     public String getEntityId(String transactionId) {
-        String mongoDatabaseName = environmentReader
-            .getMandatoryString(MONGO_DATABASE_NAME);
         String mongoCollection = environmentReader
             .getMandatoryString(MONGO_COLLECTION);
         String entityIdField = environmentReader
             .getMandatoryString(ENTITY_ID_FIELD);
 
-        MongoDatabase database = mongoClient.getDatabase(mongoDatabaseName);
+        MongoDatabase database = getDatabase();
+
         FindIterable<Document> documents = database.getCollection(mongoCollection)
             .find(Filters.eq(transactionId))
             .projection(Projections.include(entityIdField));
@@ -39,5 +39,27 @@ public class MongoService {
         String entityIdValue = (String) document.get(entityIdField);
 
         return entityIdValue;
+    }
+
+    public String getBarcode(String transactionId) {
+        String mongoCollection = environmentReader
+            .getMandatoryString(MONGO_COLLECTION);
+
+        MongoDatabase database = getDatabase();
+
+        FindIterable<Document> documents = database.getCollection(mongoCollection)
+            .find(Filters.eq(transactionId))
+            .projection(Projections.include(BARCODE_FIELD));
+        Document document = documents.first();
+        String barcode = (String) document.get(BARCODE_FIELD);
+
+        return barcode;
+    }
+
+    private MongoDatabase getDatabase() {
+        String mongoDatabaseName = environmentReader
+            .getMandatoryString(MONGO_DATABASE_NAME);
+
+        return mongoClient.getDatabase(mongoDatabaseName);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/service/MongoServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/service/MongoServiceTest.java
@@ -53,6 +53,8 @@ public class MongoServiceTest {
     private static final String ENTITY_ID = "_entity_id";
     private static final String ENTITY_ID_FIELD = "ENTITY_ID_FIELD";
     private static final String ENTITY_ID_VALUE = "112233445";
+    private static final String BARCODE = "barcode";
+    private static final String BARCODE_VALUE = "001122334";
 
     @Test
     @DisplayName("Entity id returned successfully from mongo collection")
@@ -75,5 +77,26 @@ public class MongoServiceTest {
         when(findIterableMocked.first()).thenReturn(document);
         String entityId = mongoService.getEntityId(TRANSACTION_ID);
         assertEquals(ENTITY_ID_VALUE, entityId);
+    }
+
+    @Test
+    @DisplayName("Barcode returned successfully from mongo collection")
+    void BarcodeReturnedSuccessfully() {
+        Document document = new Document();
+        document.append(ID, TRANSACTION_ID);
+        document.append(BARCODE, BARCODE_VALUE);
+
+        doReturn(COMPANY_FILING_HISTORY).when(environmentReader)
+            .getMandatoryString(MONGO_DATABASE_NAME);
+        doReturn(COMPANY_FILING_HISTORY).when(environmentReader)
+            .getMandatoryString(MONGO_COLLECTION);
+
+        when(mockMongoClient.getDatabase(anyString())).thenReturn(mockMongoDatabase);
+        when(mockMongoDatabase.getCollection(anyString())).thenReturn(mockMongoCollection);
+        when(mockMongoCollection.find(any(Bson.class))).thenReturn(findIterableMocked);
+        when(findIterableMocked.projection(any(Bson.class))).thenReturn(findIterableMocked);
+        when(findIterableMocked.first()).thenReturn(document);
+        String barcode = mongoService.getBarcode(TRANSACTION_ID);
+        assertEquals(BARCODE_VALUE, barcode);
     }
 }


### PR DESCRIPTION
If there is no `_entity_id` or `barcode` present then mongo will check for a `barcode` field
Resolves: 