### PR TITLE
GCI-1723 - Add email to the data sent to chd-order-api in the chd-order-consumer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <system-rules-version>1.17.2</system-rules-version>
         <ch-kafka.version>1.4.2</ch-kafka.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
-        <private-api-sdk-java.version>2.0.63</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.65</private-api-sdk-java.version>
         <spring-boot-dependencies.version>2.1.15.RELEASE</spring-boot-dependencies.version>
         <spring-boot-maven-plugin.version>2.1.15.RELEASE</spring-boot-maven-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/src/main/java/uk/gov/companieshouse/chdorderconsumer/service/ItemOrderedProcessorService.java
+++ b/src/main/java/uk/gov/companieshouse/chdorderconsumer/service/ItemOrderedProcessorService.java
@@ -18,6 +18,7 @@ import uk.gov.companieshouse.chdorderconsumer.exception.RetryableErrorException;
 import uk.gov.companieshouse.chdorderconsumer.exception.ServiceException;
 import uk.gov.companieshouse.orders.items.ChdItemOrdered;
 import uk.gov.companieshouse.orders.items.Item;
+import uk.gov.companieshouse.orders.items.OrderedBy;
 
 @Service
 public class ItemOrderedProcessorService {
@@ -37,6 +38,7 @@ public class ItemOrderedProcessorService {
     MissingImageDeliveryRequestApi mapChdItemOrderedToMissingImageDeliveryRequestApi(ChdItemOrdered chdItemOrdered) {
         MissingImageDeliveryRequestApi missingImageDeliveryRequestApi = new MissingImageDeliveryRequestApi();
         Item item = chdItemOrdered.getItem();
+        OrderedBy orderedBy = chdItemOrdered.getOrderedBy();
         Map<String, String> itemOptions = item.getItemOptions();
 
         missingImageDeliveryRequestApi.setId(item.getId());
@@ -50,6 +52,7 @@ public class ItemOrderedProcessorService {
         missingImageDeliveryRequestApi.setFilingHistoryType(itemOptions.get("filingHistoryType"));
         missingImageDeliveryRequestApi.setFilingHistoryBarcode(itemOptions.get("filingHistoryBarcode"));
         missingImageDeliveryRequestApi.setItemCost(item.getTotalItemCost());
+        missingImageDeliveryRequestApi.setEmailAddress(orderedBy.getEmail());
 
         String filingHistoryId = itemOptions.get("filingHistoryId");
 

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/service/ItemOrderedProcessorServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/service/ItemOrderedProcessorServiceIntegrationTest.java
@@ -14,6 +14,7 @@ import uk.gov.companieshouse.chdorderconsumer.exception.ServiceException;
 import uk.gov.companieshouse.chdorderconsumer.kafka.ItemOrderedKafkaProducer;
 import uk.gov.companieshouse.orders.items.ChdItemOrdered;
 import uk.gov.companieshouse.orders.items.Item;
+import uk.gov.companieshouse.orders.items.OrderedBy;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -50,6 +51,9 @@ class ItemOrderedProcessorServiceIntegrationTest {
         item.setCompanyNumber("00000000");
         item.setTotalItemCost("5");
 
+        OrderedBy orderedBy = new OrderedBy();
+        orderedBy.setEmail("test@email.com");
+
         Map<String, String> itemOptions = new HashMap<>();
         itemOptions.put("filingHistoryCategory", "RESOLUTIONS");
         itemOptions.put("filingHistoryDate", "2009-04-03");
@@ -62,6 +66,7 @@ class ItemOrderedProcessorServiceIntegrationTest {
         CHD_ITEM_ORDERED.setOrderedAt("2020-10-27T09:39:10.873");
         CHD_ITEM_ORDERED.setPaymentReference("payment ref");
         CHD_ITEM_ORDERED.setItem(item);
+        CHD_ITEM_ORDERED.setOrderedBy(orderedBy);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/chdorderconsumer/service/ItemOrderedProcessorServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chdorderconsumer/service/ItemOrderedProcessorServiceTest.java
@@ -34,6 +34,7 @@ import uk.gov.companieshouse.chdorderconsumer.exception.RetryableErrorException;
 import uk.gov.companieshouse.chdorderconsumer.exception.ServiceException;
 import uk.gov.companieshouse.orders.items.ChdItemOrdered;
 import uk.gov.companieshouse.orders.items.Item;
+import uk.gov.companieshouse.orders.items.OrderedBy;
 
 @ExtendWith(MockitoExtension.class)
 class ItemOrderedProcessorServiceTest {
@@ -59,6 +60,9 @@ class ItemOrderedProcessorServiceTest {
         item.setCompanyNumber("00000000");
         item.setTotalItemCost("5");
 
+        OrderedBy orderedBy = new OrderedBy();
+        orderedBy.setEmail("test@email.com");
+
         Map<String, String> itemOptions = new HashMap<>();
         itemOptions.put("filingHistoryCategory", "RESOLUTIONS");
         itemOptions.put("filingHistoryId", "fsdf2342sdf234242");
@@ -72,6 +76,7 @@ class ItemOrderedProcessorServiceTest {
         CHD_ITEM_ORDERED.setOrderedAt("2020-10-27T09:39:10.873");
         CHD_ITEM_ORDERED.setPaymentReference("payment ref");
         CHD_ITEM_ORDERED.setItem(item);
+        CHD_ITEM_ORDERED.setOrderedBy(orderedBy);
     }
 
     static {
@@ -80,6 +85,9 @@ class ItemOrderedProcessorServiceTest {
         item.setCompanyName("Company Name");
         item.setCompanyNumber("00000000");
         item.setTotalItemCost("5");
+
+        OrderedBy orderedBy = new OrderedBy();
+        orderedBy.setEmail("test@email.com");
 
         Map<String, String> itemOptions = new HashMap<>();
         itemOptions.put("filingHistoryCategory", "RESOLUTIONS");
@@ -93,6 +101,7 @@ class ItemOrderedProcessorServiceTest {
         CHD_ITEM_ORDERED_NO_BARCODE.setOrderedAt("2020-10-27T09:39:10.873");
         CHD_ITEM_ORDERED_NO_BARCODE.setPaymentReference("payment ref");
         CHD_ITEM_ORDERED_NO_BARCODE.setItem(item);
+        CHD_ITEM_ORDERED_NO_BARCODE.setOrderedBy(orderedBy);
     }
 
     @Test
@@ -114,6 +123,7 @@ class ItemOrderedProcessorServiceTest {
         assertThat(missingImageDeliveryRequestApi.getFilingHistoryBarcode(), is(CHD_ITEM_ORDERED.getItem().getItemOptions().get("filingHistoryBarcode")));
         assertThat(missingImageDeliveryRequestApi.getEntityId(), is (ENTITY_ID));
         assertThat(missingImageDeliveryRequestApi.getItemCost(), is(CHD_ITEM_ORDERED.getItem().getTotalItemCost()));
+        assertThat(missingImageDeliveryRequestApi.getEmailAddress(), is(CHD_ITEM_ORDERED.getOrderedBy().getEmail()));
     }
 
     @Test
@@ -136,6 +146,7 @@ class ItemOrderedProcessorServiceTest {
         assertThat(missingImageDeliveryRequestApi.getFilingHistoryBarcode(), is(BARCODE));
         assertNull(missingImageDeliveryRequestApi.getEntityId());
         assertThat(missingImageDeliveryRequestApi.getItemCost(), is(CHD_ITEM_ORDERED_NO_BARCODE.getItem().getTotalItemCost()));
+        assertThat(missingImageDeliveryRequestApi.getEmailAddress(), is(CHD_ITEM_ORDERED_NO_BARCODE.getOrderedBy().getEmail()));
     }
 
     @Test


### PR DESCRIPTION
Pass email obtained from the consumed kafka message to the chd-order-api
Resolves: GCI-1723