### PR TITLE
Updated Makefile for dependency check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,30 +66,3 @@ sonar:
 .PHONY: sonar-pr-analysis
 sonar-pr-analysis:
 	mvn sonar:sonar	-P sonar-pr-analysis
-
-.PHONY: dependency-check
-dependency-check:
-	@ if [ -n "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
-		if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
-			suppressions_home="$${DEPENDENCY_CHECK_SUPPRESSIONS_HOME}"; \
-		else \
-			printf -- 'DEPENDENCY_CHECK_SUPPRESSIONS_HOME is set, but its value "%s" does not point to a directory\n' "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)"; \
-			exit 1; \
-		fi; \
-	fi; \
-	if [ ! -d "$${suppressions_home}" ]; then \
-		suppressions_home_target_dir="./target/dependency-check-suppressions"; \
-		if [ -d "$${suppressions_home_target_dir}" ]; then \
-			suppressions_home="$${suppressions_home_target_dir}"; \
-		else \
-			mkdir -p "./target"; \
-			git clone git@github.com:companieshouse/dependency-check-suppressions.git "$${suppressions_home_target_dir}" && \
-				suppressions_home="$${suppressions_home_target_dir}"; \
-		fi; \
-	fi; \
-	printf -- 'suppressions_home="%s"\n' "$${suppressions_home}"; \
-	DEPENDENCY_CHECK_SUPPRESSIONS_HOME="$${suppressions_home}" "$${suppressions_home}/scripts/depcheck" --repo-name=chd-order-consumer
-
-.PHONY: security-check
-security-check: dependency-check
-

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.11</version>
+        <version>2.1.12</version>
         <relativePath/>
     </parent>
     <artifactId>chd-order-consumer</artifactId>
@@ -53,9 +53,6 @@
 			${project.basedir}/target/site/jacoco-it/jacoco.xml
 		</sonar.coverage.jacoco.xmlReportPaths>
 		<sonar.jacoco.reports>${project.basedir}/target/site</sonar.jacoco.reports>
-		<sonar.dependencyCheck.htmlReportPath>
-			${project.basedir}/target/dependency-check-report.html
-		</sonar.dependencyCheck.htmlReportPath>
 		<sonar.java.binaries>
 			${project.basedir}/target
 		</sonar.java.binaries>


### PR DESCRIPTION
removed the dependency check section from the Makefile as a part of migrating to a centralized vulnerability scanning approach managed via the CI pipeline.
Updated parent pom to 2.1.12, use relativePath 2.1.12 brings in updated dependency-check settings.